### PR TITLE
Fix compilation for macOS by Zig 0.14.x

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -16,7 +16,7 @@ pub fn build(b: *std.Build) void {
             .ENABLE_64_BIT_WORDS = target.ptrBitWidth() == 64,
             .FLAC__ALIGN_MALLOC_DATA = target.cpu.arch.isX86(),
             .FLAC__CPU_ARM64 = target.cpu.arch.isAARCH64(),
-            .FLAC__SYS_DARWIN = target.isDarwin(),
+            .FLAC__SYS_DARWIN = target.os.tag == .macos,
             .FLAC__SYS_LINUX = target.os.tag == .linux,
             .HAVE_BYTESWAP_H = target.os.tag == .linux,
             .HAVE_CPUID_H = target.cpu.arch.isX86(),


### PR DESCRIPTION
Use `target.os.tag` instead if `fn isDarwin()`


- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.